### PR TITLE
fixes sauce rest api update in hosting environment

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -135,19 +135,10 @@ def after_all(context):
         body_content = json.dumps({"passed": not context.failed})
         context.logger.info("Updating sauce job with %s" % body_content)
 
-        # If a proxy is present then use it
-        # Otherwise connect directly to saucelabs
-        http_proxy = os.getenv('http_proxy', None)
-        context.logger.info("Proxy is %s" % http_proxy)
-        
-        if http_proxy:
-            if http_proxy.startswith("http://"):
-                http_proxy = http_proxy[7:]
-            connection = httplib.HTTPConnection(http_proxy)
-        else:
-            connection = httplib.HTTPConnection("saucelabs.com")
-        
-        connection.set_debuglevel(10)
+        # If we need to go through a proxy server, see git history from August 2015 for the code to revert to
+        # See DEV-1109 in internal Jira for full discussion
+
+        connection = httplib.HTTPConnection("saucelabs.com")
         connection.request('PUT', '/rest/v1/%s/jobs/%s' %
                            (context.sauce_config['username'],
                             context.base.driver.session_id),

--- a/features/environment.py
+++ b/features/environment.py
@@ -148,7 +148,7 @@ def after_all(context):
             connection = httplib.HTTPConnection("saucelabs.com")
         
         connection.set_debuglevel(10)
-        connection.request('PUT', 'http://saucelabs.com/rest/v1/%s/jobs/%s' %
+        connection.request('PUT', '/rest/v1/%s/jobs/%s' %
                            (context.sauce_config['username'],
                             context.base.driver.session_id),
                            body_content,

--- a/features/environment.py
+++ b/features/environment.py
@@ -138,13 +138,16 @@ def after_all(context):
         # If a proxy is present then use it
         # Otherwise connect directly to saucelabs
         http_proxy = os.getenv('http_proxy', None)
+        context.logger.info("Proxy is %s" % http_proxy)
+        
         if http_proxy:
             if http_proxy.startswith("http://"):
                 http_proxy = http_proxy[7:]
             connection = httplib.HTTPConnection(http_proxy)
         else:
             connection = httplib.HTTPConnection("saucelabs.com")
-
+        
+        connection.set_debuglevel(10)
         connection.request('PUT', 'http://saucelabs.com/rest/v1/%s/jobs/%s' %
                            (context.sauce_config['username'],
                             context.base.driver.session_id),
@@ -158,7 +161,7 @@ def after_all(context):
 
 def setup_logger(context):
     # create logger
-    logger = logging.getLogger('Retirement_browser_tests: ')
+    logger = logging.getLogger('ckan_browser_tests: ')
     logger.setLevel(context.log_level)
 
     # create console handler and set level to debug


### PR DESCRIPTION
removes all the old proxy stuff since it's no longer in use in the hosting environment.

Problem is that for some reason, in this hosting environment and nowhere else that I tested, this fails:

connection.request("http://saucelabs.com/rest/....")

it just hangs

but connection.request("/rest/...") works fine.

i.e. the full URL fails, but the relative one does not.
